### PR TITLE
Handle llm package not supporting the selected model alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Once the virtual environment is activated, you can install the necessary depende
 ## Dependencies
 The agent scripts use `llm` to interact with different LLM models. More information on setting up and using `llm` can be found in its [documentation](https://llm.datasette.io/en/stable/index.html). You'll need to make sure `llm` is configured to work with at least one LLM.
 
+The tests for this project use the gemini family of models. To be able to run the tests you can follow the steps in this [documentation](https://github.com/simonw/llm-gemini). The steps are also provided more succinctly below:
+
+```
+llm install llm-gemini
+llm keys set gemini
+```
+
 The agent in `web_agent.py` uses `playwright` to launch and automate a web browser. More information on setting up and using `playwright` can be found in its Python [documentation](https://playwright.dev/python/docs/intro). You'll need to make sure `playwright` is setup to work with at least one we browser. I installed `chromium` since I do not use that for my primary web browser. That removes any conflicts between running the script and my actual browsing.
 
 To install the necessary dependencies, run:

--- a/tool_agent.py
+++ b/tool_agent.py
@@ -421,3 +421,10 @@ class ToolAgent:
             'input': 0,
             'output': 0
         }
+
+    @staticmethod
+    def get_supported_models():
+        """Return a list of supported models dynamically from the llm package."""
+        from llm import get_models_with_aliases
+        models_with_aliases = get_models_with_aliases()
+        return [model_with_alias.model.model_id for model_with_alias in models_with_aliases]

--- a/tool_agent_test.py
+++ b/tool_agent_test.py
@@ -1,3 +1,5 @@
+import llm
+
 from tool_agent import ToolAgent
 from mock_providers import UtilityToolProvider, AppointmentToolProvider, ProgramToolProvider, StoreLocatorToolProvider
 
@@ -38,4 +40,10 @@ def start_chat(model):
     print(f"  Total tokens: {usage.get('input', 0) + usage.get('output', 0)}")
 
 if __name__ == '__main__':
-    start_chat('gemini-2.0-flash')
+    try:
+        model_alias = 'gemini-2.0-flash'
+        start_chat(model=model_alias)
+
+    except llm.UnknownModelError as e:
+        print(f"\nThe model alias {model_alias} provided in the test is not supported. Error: {e}\n")
+        print(f"Supported models are: {ToolAgent.get_supported_models()}")

--- a/tool_agent_test.py
+++ b/tool_agent_test.py
@@ -47,3 +47,4 @@ if __name__ == '__main__':
     except llm.UnknownModelError as e:
         print(f"\nThe model alias {model_alias} provided in the test is not supported. Error: {e}\n")
         print(f"Supported models are: {ToolAgent.get_supported_models()}")
+        print("\nIt could be that you have not installed an llm model add on like llm-gemini for your llm package. Check out the README for more information.\n")


### PR DESCRIPTION
## Description
- Guarded the case where the supplied LLM model alias is not installed/recognized.
- Updated the readme to note how an LLM add-on can be installed and that the tests use the gemini add on.

## Context
<img width="966" alt="image" src="https://github.com/user-attachments/assets/171c9de7-8d6c-4a94-adcd-37f3cfa7fa22" />